### PR TITLE
Fix/auth

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -62,9 +62,12 @@ class AuthController extends Controller
 
     // 生成響應
     $response = response()->json([
-        'message' => "Login successful",
+        'message' => config('success_messages.LOGIN_SUCCESS'),
     ], $loginResponse['status']);
 
+
+    
+    
     // 創建 cookie
     $cookie = cookie('jwt', $loginResponse['token'], $loginResponse['token_ttl'], null, null, false, true);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -8,7 +8,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-
+use Illuminate\Support\Facades\Cookie;
 use Tymon\JWTAuth\Facades\JWTAuth;
 
 
@@ -62,7 +62,7 @@ class AuthController extends Controller
 
     // 生成響應
     $response = response()->json([
-        'message' => '登錄成功',
+        'message' => "Login successful",
     ], $loginResponse['status']);
 
     // 創建 cookie
@@ -90,64 +90,28 @@ class AuthController extends Controller
      *   "message": "Failed to logout"
      * }
      */
-    public function logout()
+    public function logout(Request $request)
     {
         try {
-            // 取出token 將其失效
-            JWTAuth::invalidate(JWTAuth::getToken());
-
-            return response()->json(['message' => 'Successfully logged out']);
-        } catch (\Exception $e) {
-            return response()->json(['message' => 'Failed to logout'], 500);
-        }
-    }
-
-    /**
-     * 註冊email驗證信確認
-     * 
+            // 從 cookie 中取出 token
+            $token = $request->cookie('jwt');
     
-     * 電子郵件驗證確認
-     *
-     * 此端點用於確認用戶的電子郵件驗證(和前端較無關聯）。
-     * 它會比對提供的hash值和用戶的電子郵件生成的hash值。
-     * 如果驗證成功，該用戶的電子郵件將被標記為已驗證，並且將觸發一個已驗證的事件。
-     * 系統會將email驗證的日期存入資料庫
-     *
-     * @param Request $request HTTP請求
-     * @param int $id 用戶ID
-     * @param string $hash 從驗證郵件中提供的hash值
-     * 
-     * @throws AuthorizationException 當提供的hash值不匹配時
-     * 
-     * @response 200 {
-     *   "message": "Email verified successfully."
-     * }
-     * 
-     * @response 200 {
-     *   "message": "Email already verified."
-     * }
-     */
-
-    public function verifyEmail(Request $request, $id, $hash)
-    {
-        $user = User::findOrFail($id);
-
-        // 此方法通常用來判斷文件是否被串改
-        if (!hash_equals((string) $hash, sha1($user->getEmailForVerification()))) {
-            throw new AuthorizationException();
+            // 將 token 設為無效
+            JWTAuth::setToken($token)->invalidate();
+    
+            // 清除客戶端的 JWT cookie
+            $cookie = Cookie::forget('jwt');
+    
+            $response = response()->json(['message' => "Successfully logged out"]);
+    
+            // 將清除 cookie 的響應附加到返回的響應中
+            return $response->withCookie($cookie);
+        } catch (\Exception $e) {
+            return response()->json(['message' => "Failed to logout"], 500);
         }
-
-        // 判斷這個email是否已經驗證過
-        if ($user->hasVerifiedEmail()) {
-            return response(['message' => 'Email already verified.']);
-        }
-
-        // 到這一步就去將他的email驗證
-        if ($user->markEmailAsVerified()) {
-            event(new Verified($user));
-        }
-
-        return response(['message' => 'Email verified successfully.']);
     }
+    
+
+
 
 }

--- a/app/Http/Controllers/PokemonController.php
+++ b/app/Http/Controllers/PokemonController.php
@@ -47,6 +47,7 @@ class PokemonController extends Controller
 
     public function index()
     {
+
         // 透過JWT取得當前登入的用戶
         $user = auth()->user();
 

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 
@@ -67,4 +69,54 @@ class RegisterController extends Controller
 
         return response(['message' => 'User registered successfully!', 'user' => $user], 201);
     }
+
+
+
+        /**
+     * 註冊email驗證信確認
+     * 
+    
+     * 電子郵件驗證確認
+     *
+     * 此端點用於確認用戶的電子郵件驗證(和前端較無關聯）。
+     * 它會比對提供的hash值和用戶的電子郵件生成的hash值。
+     * 如果驗證成功，該用戶的電子郵件將被標記為已驗證，並且將觸發一個已驗證的事件。
+     * 系統會將email驗證的日期存入資料庫
+     *
+     * @param Request $request HTTP請求
+     * @param int $id 用戶ID
+     * @param string $hash 從驗證郵件中提供的hash值
+     * 
+     * @throws AuthorizationException 當提供的hash值不匹配時
+     * 
+     * @response 200 {
+     *   "message": "Email verified successfully."
+     * }
+     * 
+     * @response 200 {
+     *   "message": "Email already verified."
+     * }
+     */
+
+     public function verifyEmail(Request $request, $id, $hash)
+     {
+         $user = User::findOrFail($id);
+ 
+         // 此方法通常用來判斷文件是否被串改
+         if (!hash_equals((string) $hash, sha1($user->getEmailForVerification()))) {
+             throw new AuthorizationException();
+         }
+ 
+         // 判斷這個email是否已經驗證過
+         if ($user->hasVerifiedEmail()) {
+             return response(['message' => 'Email already verified.']);
+         }
+ 
+         // 到這一步就去將他的email驗證
+         if ($user->markEmailAsVerified()) {
+             event(new Verified($user));
+         }
+ 
+         return response(['message' => 'Email verified successfully.']);
+     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -39,9 +39,10 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            
         ],
     ];
 
@@ -67,5 +68,12 @@ class Kernel extends HttpKernel
         // 確認使用者是否被停權
         'checkStatus' => \App\Http\Middleware\CheckUserStatus::class,
         'cors' => \App\Http\Middleware\Cors::class,
+        
+        'logcookies' => \App\Http\Middleware\LogCookies::class,
+        'jwt.cookie' =>\App\Http\Middleware\JWTAuthCookieMiddleware::class,
+
+
     ];
-}
+    
+
+    }

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -12,6 +12,6 @@ class EncryptCookies extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        'jwt',
     ];
 }

--- a/app/Http/Middleware/JWTAuthCookieMiddleware.php
+++ b/app/Http/Middleware/JWTAuthCookieMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class JWTAuthCookieMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // 尝试从 cookie 中获取 token
+        $token = $request->cookie('jwt');
+    
+        if (!$token) {
+            return response()->json(['error' => 'Token not provided'], 401);
+        } 
+
+        try {
+            // 使用 token 认证用户
+            $user = JWTAuth::setToken($token)->authenticate();
+            // 如果认证通过，将用户信息设置到请求对象中
+            Auth::setUser($user);
+        } catch (JWTException $e) {
+            // 如果在此过程中出现任何异常，返回错误响应
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+        // 继续处理请求
+        return $next($request);
+    }
+    
+}

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -2,6 +2,8 @@
 namespace App\Services;
 
 use App\Models\User;
+use Symfony\Component\HttpFoundation\Response;
+
 use Tymon\JWTAuth\Facades\JWTAuth;
 
 class AuthService
@@ -11,13 +13,16 @@ class AuthService
         // 檢查用戶是否已經驗證了電子郵箱
         $user = User::where('email', $credentials['email'])->first();
         if ($user && is_null($user->email_verified_at)) {
-            return ['error' => '信箱未驗證', 'status' => 403];
+            return ['error' => config('error_messages.EMAIL_NOT_VERIFIED'),
+            'status' => Response::HTTP_FORBIDDEN ];
         }
+        
 
         // 嘗試使用憑證獲取 JWT token
         $token = JWTAuth::attempt($credentials);
         if (!$token) {
-            return ['error' => "Invalid credentials", 'status' => 401];
+            return ['error' => config('error_messages.INVALID_CREDENTIALS'),
+            'status' => Response::HTTP_UNAUTHORIZED  ];
         }
 
         // 獲取 token 的有效期
@@ -27,7 +32,7 @@ class AuthService
         return [
             'token' => $token,
             'token_ttl' => $tokenTTL,
-            'status' => 200
+            'status' => Response::HTTP_OK
         ];
     }
 }

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Services;
+
+use App\Models\User;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class AuthService
+{
+    public function attemptLogin(array $credentials)
+    {
+        // 檢查用戶是否已經驗證了電子郵箱
+        $user = User::where('email', $credentials['email'])->first();
+        if ($user && is_null($user->email_verified_at)) {
+            return ['error' => '信箱未驗證', 'status' => 403];
+        }
+
+        // 嘗試使用憑證獲取 JWT token
+        $token = JWTAuth::attempt($credentials);
+        if (!$token) {
+            return ['error' => '無效的憑證', 'status' => 401];
+        }
+
+        // 獲取 token 的有效期
+        $tokenTTL = JWTAuth::factory()->getTTL() * 60; // 轉換為秒
+
+        // 返回 token 和其有效期
+        return [
+            'token' => $token,
+            'token_ttl' => $tokenTTL,
+            'status' => 200
+        ];
+    }
+}

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -2,6 +2,7 @@
 namespace App\Services;
 
 use App\Models\User;
+use Illuminate\Support\Facades\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 
 use Tymon\JWTAuth\Facades\JWTAuth;
@@ -34,5 +35,27 @@ class AuthService
             'token_ttl' => $tokenTTL,
             'status' => Response::HTTP_OK
         ];
+    }
+
+    public function logout($token)
+    {
+        try {
+            // 将 token 设置为无效
+            JWTAuth::setToken($token)->invalidate();
+
+            // 清除客户端的 JWT cookie
+            $cookie = Cookie::forget('jwt');
+
+            return [
+                'message' => config("success_messages.LOGOUT_SUCCESS"),
+                'status' => Response::HTTP_OK,
+                'cookie' => $cookie
+            ];
+        } catch (\Exception $e) {
+            return [
+                'error' => config("error_messages.LOGOUTFAILED"),
+                'status' => Response::HTTP_INTERNAL_SERVER_ERROR
+            ];
+        }
     }
 }

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -17,7 +17,7 @@ class AuthService
         // 嘗試使用憑證獲取 JWT token
         $token = JWTAuth::attempt($credentials);
         if (!$token) {
-            return ['error' => '無效的憑證', 'status' => 401];
+            return ['error' => "Invalid credentials", 'status' => 401];
         }
 
         // 獲取 token 的有效期

--- a/config/error_messages.php
+++ b/config/error_messages.php
@@ -1,0 +1,11 @@
+<?php
+
+// config/error_messages.php
+return [
+    'EMAIL_NOT_VERIFIED' => 'email not verify',
+    'INVALID_CREDENTIALS' => 'Invalid credentials',
+    'INVALID_CREDENTIALS' => 'Invalid credentials',
+    'INVALID_CREDENTIALS' => 'Invalid credentials',
+    // ... 其他錯誤訊息
+
+];

--- a/config/error_messages.php
+++ b/config/error_messages.php
@@ -5,7 +5,8 @@ return [
     'EMAIL_NOT_VERIFIED' => 'email not verify',
     'INVALID_CREDENTIALS' => 'Invalid credentials',
     'INVALID_CREDENTIALS' => 'Invalid credentials',
-    'INVALID_CREDENTIALS' => 'Invalid credentials',
+    'LOGOUTFAILED' => 'Failed to logout',
+    
     // ... 其他錯誤訊息
 
 ];

--- a/config/success_messages.php
+++ b/config/success_messages.php
@@ -1,0 +1,7 @@
+<?php
+
+// config/success_messages.php
+return [
+    'LOGIN_SUCCESS' => 'Login successful',
+    // ... 其他成功消息
+];

--- a/config/success_messages.php
+++ b/config/success_messages.php
@@ -3,5 +3,6 @@
 // config/success_messages.php
 return [
     'LOGIN_SUCCESS' => 'Login successful',
+    "LOGOUT_SUCCESS" => 'Successfully logged out'
     // ... 其他成功消息
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\RaceController;
 use App\Http\Controllers\RegisterController;
 use App\Http\Controllers\UserController;
 
+
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -27,7 +28,7 @@ use App\Http\Controllers\UserController;
 // Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 //     return $request->user();
 // });
-Route::middleware('auth:api', 'checkStatus', 'throttle:100000,1')->group(function () {
+Route::middleware(['jwt.cookie', 'checkStatus', 'throttle:100000,1'])->group(function () {
 
     /**
      * pokemon管理
@@ -71,6 +72,7 @@ Route::middleware('auth:api', 'checkStatus', 'throttle:100000,1')->group(functio
     // 購買金流
     Route::post('payments', [PaymentController::class, 'checkout']);
 });
+
 
 // 註冊
 Route::post('/register', [RegisterController::class, 'register']);


### PR DESCRIPTION
這個分支主要是針對登入登出API做修改：
登入：
在返回response的時候，從原本的直接返回token，改成設置cookie並把token放在裡面。
在使用者訪問其他需驗證的API，多新增了自定義的middleware，去將cookie的token取出，並做token的驗證。


登出：
主要除了讓token失效以外，也讓刪除原本設置的cookie。
